### PR TITLE
Update seed for team

### DIFF
--- a/app/models/roster.rb
+++ b/app/models/roster.rb
@@ -1,4 +1,4 @@
 class Roster < ActiveRecord::Base
   belongs_to :team
-  belongs_to :player, class_name: "User"
+  belongs_to :user
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,12 @@
 class Team < ActiveRecord::Base
-  has_many :players, through: :roster, class_name: "User"
-  has_one :roster
+  has_many :users, through: :roster
+  has_many :rosters
+
+  def managers
+    rosters.where(is_manager: true).map{ |roster| roster.user }
+  end
+
+  def line_up
+    rosters.where(in_line_up: true).map{ |roster| roster.user }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,6 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   has_one :profile
-  has_many :teams, through: :roster
   has_many :rosters
+  has_many :teams, through: :roster
 end

--- a/db/migrate/20150922194307_create_rosters.rb
+++ b/db/migrate/20150922194307_create_rosters.rb
@@ -1,7 +1,7 @@
 class CreateRosters < ActiveRecord::Migration
   def change
     create_table :rosters do |t|
-      t.references :player, index: true
+      t.references :user, index: true
       t.references :team, index: true
       t.boolean :in_line_up
       t.boolean :is_manager

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20150922194307) do
   add_index "profiles", ["user_id"], name: "index_profiles_on_user_id"
 
   create_table "rosters", force: :cascade do |t|
-    t.integer  "player_id"
+    t.integer  "user_id"
     t.integer  "team_id"
     t.boolean  "in_line_up"
     t.boolean  "is_manager"
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(version: 20150922194307) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "rosters", ["player_id"], name: "index_rosters_on_player_id"
   add_index "rosters", ["team_id"], name: "index_rosters_on_team_id"
+  add_index "rosters", ["user_id"], name: "index_rosters_on_user_id"
 
   create_table "teams", force: :cascade do |t|
     t.string   "name",       null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,17 @@ require 'faker'
 
 league = League.create( name: "Super Rad Soccer League")
 
+# Create player for testing
+user  = User.create!( name: "Test Player",
+                      email: "test@example.com",
+                   password: "password",
+      password_confirmation: "password",
+                  address_1: Faker::Address.street_address,
+                  address_2: Faker::Address.secondary_address,
+                       city: Faker::Address.city,
+                      state: Faker::Address.state_abbr,
+                        zip: Faker::Address.zip )
+
 # Create players
 players = []
 
@@ -41,13 +52,6 @@ refs = []
   refs << ref
 end
 
-# # seed db with teams and managers, users must be created first
-# teams = []
-
-# (0..9).each do |num|
-#   manager = User.find(num)
-#   team = Team.create!( name: Faker::Team.creature )
-#   team_with_manager = team.teamPlayer.create!( manager: true )
-# end
-
-
+10.times do
+  Team.create!( name: Faker::Team.creature )
+end


### PR DESCRIPTION
Recreated the association between users/teams/rosters.
As strange as it sounds, each team has multiple 'rosters', each roster is an association with a different player.

The association is user has many teams through rosters, teams have many users through rosters.

All mentions of `player` from this association was removed and replaced with `user` for simplicity, which updated the schema.
I had to `rake db:drop`, `create`, `migrate` in order for schema to update correctly.
