### PR TITLE
fix header formatting so sign out on same line

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <% if current_user.present? %>
-  <p><strong>Signed in as: </strong><%= current_user.name %></p> |
-  <%= link_to "Sign out", destroy_user_session_path, method: :delete %>
+  <p><strong>Signed in as: </strong><%= current_user.name %> |
+  <%= link_to "Sign out", destroy_user_session_path, method: :delete %></p>
 <% else %>
   <%= link_to "Sign in", new_user_session_path %> |
   <%= link_to "Sign up", new_user_registration_path %>


### PR DESCRIPTION
Fix the header formatting so sign out is on same line as displayed email.
